### PR TITLE
Fixes Seed inconsistency among workers

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.8.6
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,13 +30,16 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
+        . neuro/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Type Checks with mypy
       run: |
+        . neuro/bin/activate
         mypy --follow-imports=normal . || true
     - name: Test with pytest
       run: |
+        . neuro/bin/activate
         PYTHONPATH=./neuro_evolution_ctrnn pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,23 +23,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install virtualenv
-        virtualenv neuro --python=python3
-        . neuro/bin/activate
-        pip install --upgrade -r requirements.txt
-        pip install flake8
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        . neuro/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Type Checks with mypy
       run: |
-        . neuro/bin/activate
         mypy --follow-imports=normal . || true
     - name: Test with pytest
       run: |
-        . neuro/bin/activate
         PYTHONPATH=./neuro_evolution_ctrnn pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,12 +19,15 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8.5
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install virtualenv
+        virtualenv neuro --python=python3
+        . neuro/bin/activate
+        pip install --upgrade -r requirements.txt
+        pip install flake8
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8.6
+        python-version: 3.8.5
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/neuro_evolution_ctrnn/tools/algorithms.py
+++ b/neuro_evolution_ctrnn/tools/algorithms.py
@@ -12,9 +12,9 @@ import copy
 
 def evaluate_candidates(candidates, toolbox):
     if toolbox.initial_seed:
-        seed_after_map: int = random.randint(1, 10000)
+        seed_after_map: int = np.random.randint(1, 10000)
         if toolbox.conf.fix_seed_for_generation:
-            seed_for_generation = random.randint(1, 10000)
+            seed_for_generation = np.random.randint(1, 10000)
             seeds_for_evaluation: np.ndarray = seed_for_generation * np.ones(len(candidates), dtype=np.int64)
             seeds_for_recorded = seed_for_generation * np.ones(len(toolbox.recorded_individuals), dtype=np.int64)
         else:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -22,14 +22,11 @@ class TestExperiment:
         # when you do, don't forget to repeat an experiment you know will yield good results to make
         # sure nothing broke when you changed the underlying algorithm
 
-        # note; this value depends on the machine
-        accepted_results = [-99.11361202453168,  # result on bjoern's notebook
-                            -98.95448135483025,  # result on bjoern's desktop
-                            -92.24354731262838,  # result on Patrick's notebook
-                            -116.79799970080285,  # result on Github Action Public Runner
-                            -99.78831700269642  # result on se-catalpa
-                            ]
-
+        # note; this value depends on the NumPy version used, i.e. with or without Intel MKL
+        accepted_results = [
+            -103.4065390603272,  # standard NumPy
+            -102.16727461334207  # NumPy + MKL
+        ]
         assert experiment_dask.result_handler.result_log.chapters["fitness"][-1]["max"] in accepted_results
 
         experiment_mp = Experiment(configuration=config,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -25,10 +25,12 @@ class TestExperiment:
         # Note that these versions depend on whether one uses a virtualenv created with the standard Python virtualenv
         # tool package or with Anaconda. Also this value changes when standard NumPy or NumPy + MKL is used.
         # I don't think this list is exhausted, expand or change accordingly if necessary.
+        # Also the GitHub Action Runner has a different result than the standard Python virtualenv for some reason
         accepted_results = [
-            -103.4065390603272,  # conda 4.9.2 + standard NumPy
-            -102.16727461334207,  # conda 4.9.2 + NumPy + MKL
-            -98.80537742389652  # Python virtualenv + standard NumPy
+            -103.4065390603272,  # Python 3.8 + conda 4.9.2 + standard NumPy
+            -102.16727461334207,  # Python 3.8 + conda 4.9.2 + NumPy + MKL
+            -98.80537742389652,  # Python 3.8 + Python virtualenv + standard NumPy
+            -98.9895922078135  # Python 3.8 in GitHub Action Runner
         ]
 
         assert experiment_dask.result_handler.result_log.chapters["fitness"][-1]["max"] in accepted_results

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -22,11 +22,15 @@ class TestExperiment:
         # when you do, don't forget to repeat an experiment you know will yield good results to make
         # sure nothing broke when you changed the underlying algorithm
 
-        # note; this value depends on the NumPy version used, i.e. with or without Intel MKL
+        # Note that these versions depend on whether one uses a virtualenv created with the standard Python virtualenv
+        # tool package or with Anaconda. Also this value changes when standard NumPy or NumPy + MKL is used.
+        # I don't think this list is exhausted, expand or change accordingly if necessary.
         accepted_results = [
-            -103.4065390603272,  # standard NumPy
-            -102.16727461334207  # NumPy + MKL
+            -103.4065390603272,  # conda 4.9.2 + standard NumPy
+            -102.16727461334207,  # conda 4.9.2 + NumPy + MKL
+            -98.80537742389652  # Python virtualenv + standard NumPy
         ]
+
         assert experiment_dask.result_handler.result_log.chapters["fitness"][-1]["max"] in accepted_results
 
         experiment_mp = Experiment(configuration=config,


### PR DESCRIPTION
Replaced `random` with `np.random` to generate random Integers. Oddly enough this fixes different results in the `TestExperiment.test_run()` test case, maybe random does not work well with parallel processing.

Note that I removed all `accepted_results` and inserted two new ones, which should be the correct ones:
```python
accepted_results = [
    -103.4065390603272,  # standard NumPy
    -102.16727461334207  # NumPy + MKL
]
```

The first is for using standard NumPy and the other is NumPy with the [Intel Math Kernel Library](https://software.intel.com/content/www/us/en/develop/articles/numpyscipy-with-intel-mkl.html). Seems like that Intel MKL does some things that change the results.

I tested the values by creating three new conda environments with Python3.6, Python3.7 and Python3.8 respectively. I simply executed `pip install --upgrade -r requirements.txt` for the setup and changed nothing else on the environments. Then I executed the test case and got the first value for every environment.
Then I did `pip uninstall numpy` followed by a `conda install numpy` which installs NumPy with MKL extensions. After executing the test case I got the second value for each environment.

@bjuergens Could you test if you have the same value when you checkout this branch? What Python version are you using? Do you use Intel MKL?