### PR TITLE
Remove creator calls

### DIFF
--- a/neuro_evolution_ctrnn/optimizer/creator_classes.py
+++ b/neuro_evolution_ctrnn/optimizer/creator_classes.py
@@ -1,0 +1,12 @@
+from deap import base
+
+
+class FitnessMax(base.Fitness):
+    weights = (1.0,)
+
+
+class Individual(list):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.fitness = FitnessMax()

--- a/neuro_evolution_ctrnn/optimizer/i_optimizer.py
+++ b/neuro_evolution_ctrnn/optimizer/i_optimizer.py
@@ -1,18 +1,18 @@
 import abc
-from tools.configurations import IOptimizerCfg
-import numpy as np
-from gym.spaces import Space, Discrete, Box
-from typing import TypeVar, Generic, Callable
-from deap import tools
-from pathlib import Path
+import copy
 import logging
 import os
-from tools.helper import write_checkpoint
-from tools.helper import normalized_compression_distance, euklidian_distance, equal_elements_distance
-from deap import base
-import copy
 
-ConfigClass = TypeVar('ConfigClass', bound=IOptimizerCfg)
+from deap import base, tools
+import numpy as np
+from pathlib import Path
+from typing import TypeVar, Generic, Callable
+
+from tools.helper import write_checkpoint, normalized_compression_distance, euklidian_distance, equal_elements_distance
+from tools.configurations import IOptimizerCfg
+
+
+ConfigClass = TypeVar("ConfigClass", bound=IOptimizerCfg)
 
 
 class IOptimizer(abc.ABC, Generic[ConfigClass]):
@@ -20,8 +20,7 @@ class IOptimizer(abc.ABC, Generic[ConfigClass]):
     @abc.abstractmethod
     def __init__(self, eval_fitness: Callable, individual_size: int, random_seed: int, conf: ConfigClass, stats,
                  map_func=map,
-                 from_checkoint=None):
-        self.create_classes()
+                 from_checkpoint=None):
         self.conf: ConfigClass = conf
         self.toolbox = toolbox = base.Toolbox()
         self.toolbox.stats = stats
@@ -37,11 +36,6 @@ class IOptimizer(abc.ABC, Generic[ConfigClass]):
 
         if conf.novelty and not conf.fix_seed_for_generation:
             logging.warning("When using novelty you should also set fix_seed_for_generation to true. ")
-
-    @staticmethod
-    @abc.abstractmethod
-    def create_classes():
-        pass
 
     @abc.abstractmethod
     def train(self, number_generations) -> tools.Logbook:

--- a/neuro_evolution_ctrnn/optimizer/optimizer_cma_es.py
+++ b/neuro_evolution_ctrnn/optimizer/optimizer_cma_es.py
@@ -1,31 +1,25 @@
-import logging
-import os
-from pathlib import Path
 from typing import Callable
-from deap import base
-from deap import creator
+
 from deap import tools
 from deap import cma
+
+from optimizer.i_optimizer import IOptimizer
+from optimizer.creator_classes import Individual
 from tools import algorithms
 from tools.configurations import OptimizerCmaEsCfg
-from optimizer.i_optimizer import IOptimizer
 from tools.helper import get_checkpoint
 
 
 class OptimizerCmaEs(IOptimizer[OptimizerCmaEsCfg]):
-    @staticmethod
-    def create_classes():
-        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-        creator.create("Individual", list, typecode='b', fitness=creator.FitnessMax)
 
     def __init__(self, eval_fitness: Callable, individual_size: int, random_seed: int, conf: OptimizerCmaEsCfg, stats,
-                 map_func=map, from_checkoint=None):
+                 map_func=map, from_checkpoint=None):
         super(OptimizerCmaEs, self).__init__(eval_fitness, individual_size, random_seed, conf, stats, map_func,
-                                             from_checkoint)
+                                             from_checkpoint)
         toolbox = self.toolbox
 
-        if from_checkoint:
-            cp = get_checkpoint(from_checkoint)
+        if from_checkpoint:
+            cp = get_checkpoint(from_checkpoint)
             toolbox.initial_generation = cp["generation"] + 1
             self.hof = cp["halloffame"]
             toolbox.recorded_individuals = cp["recorded_individuals"]
@@ -46,7 +40,7 @@ class OptimizerCmaEs(IOptimizer[OptimizerCmaEsCfg]):
             toolbox.strategy = cma.Strategy(centroid=[0.0] * individual_size, sigma=conf.sigma,
                                             lambda_=conf.population_size, mu=mu)
 
-        toolbox.register("generate", toolbox.strategy.generate, creator.Individual)
+        toolbox.register("generate", toolbox.strategy.generate, Individual)
         toolbox.register("update", toolbox.strategy.update)
         toolbox.register("strip_strategy_from_population", self.strip_strategy_from_population,
                          mutation_learned=False)

--- a/neuro_evolution_ctrnn/optimizer/optimizer_mu_lambda.py
+++ b/neuro_evolution_ctrnn/optimizer/optimizer_mu_lambda.py
@@ -1,12 +1,13 @@
-from deap import base
-from deap import creator
-from deap import tools
-from tools import algorithms
-import numpy as np
 import random
-from optimizer.i_optimizer import IOptimizer
-from tools.configurations import OptimizerMuLambdaCfg
 from typing import Callable
+
+from deap import tools
+import numpy as np
+
+from optimizer.creator_classes import Individual
+from optimizer.i_optimizer import IOptimizer
+from tools import algorithms
+from tools.configurations import OptimizerMuLambdaCfg
 from tools.helper import get_checkpoint
 
 
@@ -16,16 +17,12 @@ def sel_elitist_tournament(individuals, mu, k_elitist, k_tournament, tournsize, 
 
 
 class OptimizerMuPlusLambda(IOptimizer[OptimizerMuLambdaCfg]):
-    @staticmethod
-    def create_classes():
-        creator.create("FitnessMax", base.Fitness, weights=(1.0,))
-        creator.create("Individual", list, typecode='b', fitness=creator.FitnessMax)
 
     def __init__(self, eval_fitness: Callable, individual_size: int, random_seed: int, conf: OptimizerMuLambdaCfg,
                  stats,
-                 map_func=map, from_checkoint=None):
+                 map_func=map, from_checkpoint=None):
         super(OptimizerMuPlusLambda, self).__init__(eval_fitness, individual_size, random_seed, conf, stats, map_func,
-                                                    from_checkoint)
+                                                    from_checkpoint)
         toolbox = self.toolbox
 
         if self.conf.strategy_parameter_per_gene:
@@ -37,7 +34,7 @@ class OptimizerMuPlusLambda(IOptimizer[OptimizerMuLambdaCfg]):
                          -self.conf.initial_gene_range,
                          self.conf.initial_gene_range,
                          individual_size)
-        toolbox.register("individual", tools.initIterate, creator.Individual, toolbox.indices)
+        toolbox.register("individual", tools.initIterate, Individual, toolbox.indices)
         toolbox.register("population", tools.initRepeat, list, toolbox.individual)
 
         mate_list = [
@@ -82,8 +79,8 @@ class OptimizerMuPlusLambda(IOptimizer[OptimizerMuLambdaCfg]):
         else:
             toolbox.register("select", tools.selBest)
 
-        if from_checkoint:
-            cp = get_checkpoint(from_checkoint)
+        if from_checkpoint:
+            cp = get_checkpoint(from_checkpoint)
             toolbox.initial_generation = cp["generation"] + 1
             toolbox.initial_seed = cp["last_seed"]
             toolbox.population = cp["population"]

--- a/neuro_evolution_ctrnn/processing_handlers/dask_handler.py
+++ b/neuro_evolution_ctrnn/processing_handlers/dask_handler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Optional, Union
+from typing import Optional, Union
 
 from dask.distributed import Client, Worker, WorkerPlugin, LocalCluster
 
@@ -10,16 +10,13 @@ from processing_handlers.i_processing_handler import IProcessingHandler
 class _CreatorPlugin(WorkerPlugin):
     """Initiated global states for every worker."""
 
-    def __init__(self, class_creator_callback: Callable, brain_class: Union[ContinuousTimeRNN]):
-        self.callback = class_creator_callback
-
+    def __init__(self, brain_class: Union[ContinuousTimeRNN]):
         # Get Class-Variable from main thread to re-initialize them on worker
         self.brain_class = brain_class
         self.brain_class_state = brain_class.get_class_state()
 
     def setup(self, worker):
         logging.debug("setting up classes for worker: " + str(worker))
-        self.callback()
         self.brain_class.set_class_state(**self.brain_class_state)
 
     def teardown(self, worker: Worker):
@@ -33,12 +30,11 @@ class _CreatorPlugin(WorkerPlugin):
 class DaskHandler(IProcessingHandler):
     """This class wraps all Dask related functions."""
 
-    def __init__(self, number_of_workers, class_cb: Callable, brain_class, worker_log_level=logging.WARNING):
+    def __init__(self, number_of_workers, brain_class, worker_log_level=logging.WARNING):
         super().__init__(number_of_workers)
         self._client: Optional[Client] = None
         self._cluster: Optional[LocalCluster] = None
 
-        self.class_cb = class_cb
         self.brain_class = brain_class
         self.worker_log_level = worker_log_level
 
@@ -55,7 +51,7 @@ class DaskHandler(IProcessingHandler):
                                      lifetime='1 hour', lifetime_stagger='5 minutes', lifetime_restart=True,
                                      interface="lo")
         self._client = Client(self._cluster)
-        self._client.register_worker_plugin(_CreatorPlugin(self.class_cb, self.brain_class), name="creator-plugin")
+        self._client.register_worker_plugin(_CreatorPlugin(self.brain_class), name="creator-plugin")
         logging.info("Dask dashboard available at port: " + str(self._client.scheduler_info()["services"]["dashboard"]))
 
     def map(self, func, *iterable):

--- a/neuro_evolution_ctrnn/tools/experiment.py
+++ b/neuro_evolution_ctrnn/tools/experiment.py
@@ -113,12 +113,12 @@ class Experiment(object):
                                "".format(self.number_of_workers, system_cpu_count))
 
         if self.processing_framework == "dask":
-            self.processing_handler = DaskHandler(self.number_of_workers, self.optimizer_class.create_classes,
-                                                  self.brain_class)
+            self.processing_handler = DaskHandler(
+                number_of_workers=self.number_of_workers, brain_class=self.brain_class)
         elif self.processing_framework == "mp":
-            self.processing_handler = MPHandler(self.number_of_workers)
+            self.processing_handler = MPHandler(number_of_workers=self.number_of_workers)
         elif self.processing_framework == "sequential":
-            self.processing_handler = SequentialHandler(self.number_of_workers)
+            self.processing_handler = SequentialHandler(number_of_workers=self.number_of_workers)
         else:
             raise RuntimeError(
                 "The processing framework '{}' is not supported.".format(self.processing_framework))
@@ -128,7 +128,7 @@ class Experiment(object):
         self.optimizer = self.optimizer_class(map_func=map_func,
                                               individual_size=self.individual_size,
                                               eval_fitness=self.ep_runner.eval_fitness, conf=self.config.optimizer,
-                                              stats=stats, from_checkoint=self.from_checkpoint,
+                                              stats=stats, from_checkpoint=self.from_checkpoint,
                                               random_seed=self.config.random_seed)
 
         self.result_handler = ResultHandler(result_path=self.result_path,

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -6,12 +6,12 @@ import os
 class TestConfigReader:
 
     def test_basic_init(self):
-        config_location = os.path.join(os.getcwd(), "basic_test_config.json")
+        config_location = os.path.join(os.getcwd(), "tests/basic_test_config.json")
         config = ConfigReader.config_from_file(config_location)
         assert config.brain.number_neurons == 2
 
     def test_cnn_init_exp(self, tmpdir):
-        config_location = os.path.join(os.getcwd(), "../configurations/cnn_ctrnn.json")
+        config_location = os.path.join(os.getcwd(), "configurations/cnn_ctrnn.json")
 
         config = ConfigReader.config_from_file(config_location)
         Experiment(configuration=config,


### PR DESCRIPTION
Removes calls to `creator.create()`, the resulting classes are implemented directly like shown [in the documentation of DEAP](https://deap.readthedocs.io/en/master/api/creator.html).

One question is if a variable is a class variable or an instance variable. In DEAP they make everything as class variables except objects which are of instance `type` as seen in this code from `deap.creator.create()`:

```python
        if isinstance(obj, type):
            dict_inst[obj_name] = obj
        else:
            dict_cls[obj_name] = obj
```

I made the classes accordingly.

Closes #33.